### PR TITLE
Kulaté stoly - link

### DIFF
--- a/app/presenters/templates/Homepage/history.latte
+++ b/app/presenters/templates/Homepage/history.latte
@@ -17,7 +17,7 @@
 
             <p class="center-custom scaled-image"><img src="{$basePath}/img/history/kulateStoly.png" sty></p>
 
-            <p>Kulaté stoly je setkání zástupců škol a firem u jednoho stolu při řešení témat jak více zapojit mladé studenty do reálné praxe a jak více propojit teoretický svět škol s praktickým pohledem firem s cílem zajímavé spolupráce. Akce se dříve konala jako doprovodný program barcampu, ale zájem o ni vzrostl natolik, že jsme ji pojali jako samostatnou akci a koná se již v jiný den, než akce pro studenty samotné. Letošní třetí ročník se koná 20. 3. a zájemci z řad škol a firem se mohou hlásit týmu odpovědnému za organizaci akce (Michaela Kosíková a Jakub Řezníček, viz. kontakty)</p>
+            <p><a href="https://www.kulatestoly.cz" target="_blank" rel="noopener">Kulaté stoly</a> je setkání zástupců škol a firem u jednoho stolu při řešení témat jak více zapojit mladé studenty do reálné praxe a jak více propojit teoretický svět škol s praktickým pohledem firem s cílem zajímavé spolupráce. Akce se dříve konala jako doprovodný program barcampu, ale zájem o ni vzrostl natolik, že jsme ji pojali jako samostatnou akci a koná se již v jiný den, než akce pro studenty samotné. Letošní třetí ročník se koná 20. 3. a zájemci z řad škol a firem se mohou hlásit týmu odpovědnému za organizaci akce (Michaela Kosíková a Jakub Řezníček, viz. kontakty)</p>
 
             <p class="center-custom scaled-image"><img src="{$basePath}/img/history/kulateStoly2.png"></p>
 


### PR DESCRIPTION
Přidá odkaz do článku [O Akci](https://prazskybarcamp.cz/2019/o-akci), což zatím nejde použít, protože https://www.kulatestoly.cz nefunguje (nefunguje HTTPS).